### PR TITLE
Fix indentation for first-level folders

### DIFF
--- a/src/scss/Plugins/Core/fileExplorer.scss
+++ b/src/scss/Plugins/Core/fileExplorer.scss
@@ -48,7 +48,7 @@
 	}
 	
 	.nav-file:not(.mod-root),
-	.nav-folder:not(.mod-root) {
+	.nav-folder:not(.mod-root) > .nav-folder-children > .nav-folder {
 		margin-left: var(--file-explorer-left-margin);
 	}
 }


### PR DESCRIPTION
First-level folders shouldn't have margin, and only sub-folders should do.
I changed the selector to only match the sub-folders.

Here's a test to show the new selector is working correctly:
![image](https://user-images.githubusercontent.com/31452340/177964316-b3f027ed-3b63-44c6-82f0-b0e3a3c0fdc0.png)
![image](https://user-images.githubusercontent.com/31452340/177964369-9556bad1-7540-408b-9c5a-ccf7c1a999a1.png)
