### PR TITLE
Add support for callouts with no header

### DIFF
--- a/src/scss/Editor/callouts.scss
+++ b/src/scss/Editor/callouts.scss
@@ -10,6 +10,13 @@
 		min-height: 36px;
 		border: 2px solid;
 		border-radius: var(--radius-m);
+		
+		&:empty + .callout-content {
+			border-radius: var(--radius-m);
+			border-top-width: 1px;
+			border-top-style: solid;
+			padding: var(--size-4-1) var(--size-4-3);
+		}
 	}
 
 	.callout-title-inner {


### PR DESCRIPTION
[Obsidian Admontion](https://github.com/valentine195/obsidian-admonition) has the option to create callouts without a title. This pull-request adds support for it by giving the callout content a top border when callout title is empty.